### PR TITLE
Rewrite tools in C++ Qt skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ set(PROJECT_SOURCES
     mainwindow.cpp
     mainwindow.h
     mainwindow.ui
+    collectpostsworker.cpp
+    collectpostsworker.h
+    collectcontactsworker.cpp
+    collectcontactsworker.h
+    dispatchworker.cpp
+    dispatchworker.h
 )
 
 qt_add_executable(${PROJECT_NAME}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# TeleTools
+
+Qt Widgets application written in C++ that provides several helper tools for Telegram work:
+
+- **Collect Posts** – gathers links to channel posts that have comments.
+- **Collect Contacts** – loads a list of post URLs and extracts unique commenters.
+- **Dispatch / Invite** – sends messages or invites to users with basic rate limiting and logging.
+
+The current implementation contains placeholder logic; integrate Telegram through TDLib or another library as needed.
+
+## Build
+
+```bash
+cmake -S . -B build && cmake --build build
+```
+
+Run the resulting binary `TeleTools` from the `build` directory.

--- a/collectcontactsworker.cpp
+++ b/collectcontactsworker.cpp
@@ -1,0 +1,24 @@
+#include "collectcontactsworker.h"
+#include <QThread>
+#include <QVariantMap>
+
+CollectContactsWorker::CollectContactsWorker(const QStringList &posts, QObject *parent)
+    : QThread(parent), m_posts(posts) {}
+
+void CollectContactsWorker::run() {
+    // Placeholder implementation: simulate collecting commenters
+    // TODO: integrate Telegram TDLib logic here
+    int total = m_posts.size();
+    for (int i = 0; i < total; ++i) {
+        QThread::sleep(1);
+        QVariantMap row;
+        row["user_id"] = QString("%1").arg(1000 + i);
+        row["username"] = QString("user%1").arg(i);
+        row["first_name"] = QString("Name%1").arg(i);
+        row["last_name"] = QString("Surname%1").arg(i);
+        row["t.me_link"] = QString("https://t.me/user%1").arg(i);
+        m_data << row;
+        emit progress(i + 1, total);
+    }
+    emit finished();
+}

--- a/collectcontactsworker.h
+++ b/collectcontactsworker.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <QThread>
+#include <QStringList>
+#include <QVariantList>
+
+class CollectContactsWorker : public QThread {
+    Q_OBJECT
+public:
+    explicit CollectContactsWorker(const QStringList &posts, QObject *parent = nullptr);
+    QVariantList data() const { return m_data; }
+signals:
+    void progress(int done, int total);
+    void finished();
+    void error(const QString &msg);
+protected:
+    void run() override;
+private:
+    QStringList m_posts;
+    QVariantList m_data;
+};

--- a/collectpostsworker.cpp
+++ b/collectpostsworker.cpp
@@ -1,0 +1,19 @@
+#include "collectpostsworker.h"
+#include <QThread>
+#include <QRegularExpression>
+#include <QTimer>
+
+CollectPostsWorker::CollectPostsWorker(const QString &channelUrl, QObject *parent)
+    : QThread(parent), m_url(channelUrl) {}
+
+void CollectPostsWorker::run() {
+    // Placeholder implementation: simulate collecting posts
+    // TODO: integrate Telegram TDLib logic here
+    const int total = 5; // simulate 5 posts
+    for (int i = 1; i <= total; ++i) {
+        QThread::sleep(1);
+        m_posts << QString("https://t.me/%1/%2").arg("demo_channel").arg(i);
+        emit progress(i, total);
+    }
+    emit finished();
+}

--- a/collectpostsworker.h
+++ b/collectpostsworker.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <QThread>
+#include <QStringList>
+
+class CollectPostsWorker : public QThread {
+    Q_OBJECT
+public:
+    explicit CollectPostsWorker(const QString &channelUrl, QObject *parent = nullptr);
+    QStringList posts() const { return m_posts; }
+signals:
+    void progress(int done, int total);
+    void finished();
+    void error(const QString &msg);
+protected:
+    void run() override;
+private:
+    QString m_url;
+    QStringList m_posts;
+};

--- a/dispatchworker.cpp
+++ b/dispatchworker.cpp
@@ -1,0 +1,33 @@
+#include "dispatchworker.h"
+#include <QThread>
+#include <QFile>
+#include <QTextStream>
+
+DispatchWorker::DispatchWorker(Mode mode,
+                               const QString &usersFile,
+                               const QString &groupName,
+                               const QString &message,
+                               QObject *parent)
+    : QThread(parent), m_mode(mode), m_usersFile(usersFile), m_group(groupName), m_message(message) {}
+
+void DispatchWorker::run() {
+    // Placeholder: simulate sending messages or invites
+    // TODO: integrate Telegram TDLib logic here
+    QFile f(m_usersFile);
+    QStringList lines;
+    if (f.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&f);
+        while (!in.atEnd()) lines << in.readLine();
+    }
+    int total = lines.size();
+    if (total == 0) {
+        emit finished();
+        return;
+    }
+    for (int i = 0; i < total; ++i) {
+        QThread::sleep(1);
+        emit log(QString("Processed %1").arg(lines.at(i)));
+        emit progress(i + 1, total);
+    }
+    emit finished();
+}

--- a/dispatchworker.h
+++ b/dispatchworker.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <QThread>
+#include <QStringList>
+
+class DispatchWorker : public QThread {
+    Q_OBJECT
+public:
+    enum Mode { Invite, Message };
+    DispatchWorker(Mode mode,
+                   const QString &usersFile,
+                   const QString &groupName,
+                   const QString &message,
+                   QObject *parent = nullptr);
+signals:
+    void progress(int done, int total);
+    void log(const QString &text);
+    void finished();
+protected:
+    void run() override;
+private:
+    Mode m_mode;
+    QString m_usersFile;
+    QString m_group;
+    QString m_message;
+};

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -1,5 +1,11 @@
 #pragma once
 #include <QMainWindow>
+#include <QStringList>
+#include <QVariantList>
+
+#include "collectpostsworker.h"
+#include "collectcontactsworker.h"
+#include "dispatchworker.h"
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -29,4 +35,12 @@ private slots:
 private:
     Ui::MainWindow *ui;
     void wireUi();
+
+    // runtime data
+    QStringList m_posts;
+    QVariantList m_contacts;
+
+    CollectPostsWorker *m_postsWorker = nullptr;
+    CollectContactsWorker *m_contactsWorker = nullptr;
+    DispatchWorker *m_dispatchWorker = nullptr;
 };


### PR DESCRIPTION
## Summary
- replace Python utilities with C++ Qt Widgets application skeleton
- add worker threads for collecting posts, contacts, and dispatching
- update CMake and documentation to reflect C++ build

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_689898ee3f888328a0c146a1d4ca1feb