### PR TITLE
Disable unavailable UI actions and adjust Qt dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(TeleTools LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 6.5 COMPONENTS Widgets REQUIRED)
+find_package(Qt6 6.4 COMPONENTS Widgets REQUIRED)
 qt_standard_project_setup()
 
 set(PROJECT_SOURCES

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -38,6 +38,11 @@ void MainWindow::wireUi() {
     ui->spinMaxDelay->setRange(0, 1200);  ui->spinMaxDelay->setValue(8);
     ui->spinMaxErrors->setRange(0, 1000); ui->spinMaxErrors->setValue(20);
     ui->checkSkipProcessed->setChecked(true);
+
+    // disable actions that require data
+    ui->btnSavePosts->setEnabled(false);
+    ui->btnRunContacts->setEnabled(false);
+    ui->btnSaveContacts->setEnabled(false);
 }
 
 // ── Посты (заглушки) ───────────────────────────────────────────
@@ -48,6 +53,7 @@ void MainWindow::onCollectPosts() {
         return;
     }
     ui->btnCollectPosts->setEnabled(false);
+    ui->btnSavePosts->setEnabled(false);
     ui->labelPostsStatus->setText("Сбор…");
     ui->progressPosts->setValue(0);
 
@@ -104,6 +110,8 @@ void MainWindow::onPickPostsFile() {
         while (!in.atEnd()) m_posts << in.readLine().trimmed();
     }
     ui->labelContactsStatus->setText(QString("Постов: %1").arg(m_posts.size()));
+    ui->btnRunContacts->setEnabled(!m_posts.isEmpty());
+    ui->btnSaveContacts->setEnabled(false);
 }
 
 void MainWindow::onRunCollectContacts() {
@@ -112,6 +120,7 @@ void MainWindow::onRunCollectContacts() {
         return;
     }
     ui->btnRunContacts->setEnabled(false);
+    ui->btnSaveContacts->setEnabled(false);
     ui->labelContactsStatus->setText("Сбор…");
     ui->progressContacts->setValue(0);
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -62,6 +62,7 @@
           </item>
           <item>
            <widget class="QPushButton" name="btnSavePosts">
+            <property name="enabled"><bool>false</bool></property>
             <property name="text">
              <string>Сохранить…</string>
             </property>
@@ -134,11 +135,13 @@
          <layout class="QHBoxLayout" name="hbox3">
           <item>
            <widget class="QPushButton" name="btnRunContacts">
+            <property name="enabled"><bool>false</bool></property>
             <property name="text"><string>Собрать контакты</string></property>
            </widget>
           </item>
           <item>
            <widget class="QPushButton" name="btnSaveContacts">
+            <property name="enabled"><bool>false</bool></property>
             <property name="text"><string>Сохранить…</string></property>
            </widget>
           </item>


### PR DESCRIPTION
## Summary
- Require Qt 6.4 instead of 6.5 to match installed libraries.
- Disable save/run buttons until necessary data is loaded, preventing invalid actions.
- Mark related buttons as disabled in the UI layout.

## Testing
- `cmake -S . -B cmake_build && cmake --build cmake_build`


------
https://chatgpt.com/codex/tasks/task_e_6898a2574e70832887f9654d5d292577